### PR TITLE
Simplify button removal

### DIFF
--- a/src/themes/theme-context.js
+++ b/src/themes/theme-context.js
@@ -1,5 +1,4 @@
-import { createContext, useState, useContext } from "react";
-import { LinkButton } from "../link";
+import { createContext, useState } from "react";
 
 export const THEME_CARD = "THEME_CARD";
 export const THEME_SIMPLE = "THEME_SIMPLE";
@@ -26,21 +25,6 @@ export const ThemeProvider = ({ children }) => {
     >
       {children}
     </ThemeContext.Provider>
-  );
-};
-
-export const ChangeThemeButton = () => {
-  const { theme, changeTheme } = useContext(ThemeContext);
-
-  return (
-    <LinkButton
-      onClick={() => {
-        changeTheme();
-      }}
-    >
-      {theme === THEME_CARD && "[simplify]"}
-      {theme === THEME_SIMPLE && "[complicate]"}
-    </LinkButton>
   );
 };
 


### PR DESCRIPTION
Remove the `[simplify]` button as it is not functional.

The `ChangeThemeButton` component and its related imports were removed, while the core theming infrastructure was preserved for future use.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8488e10a-7c5e-46fa-92a2-22d017c2bae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8488e10a-7c5e-46fa-92a2-22d017c2bae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

